### PR TITLE
Improve logging output with rich console

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -3,6 +3,7 @@ from rich.live import Live
 from rich.table import Table
 from rich.panel import Panel
 from rich.layout import Layout
+from utils.logging import log
 from time import sleep
 
 class Dashboard:
@@ -84,7 +85,7 @@ class Dashboard:
         return layout
 
     def run(self, update_fn):
-        with Live(self.render(), refresh_per_second=1, screen=True) as live:
+        with Live(self.render(), refresh_per_second=1, screen=True, console=log.console) as live:
             try:
                 while not self.stop_event.is_set():
                     update_fn()

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,15 +1,17 @@
 # utils/logging.py
 from datetime import datetime
 from collections import deque
+from rich.console import Console
 
 class Logger:
     def __init__(self, max_lines=100):
         self.logs = deque(maxlen=max_lines)
+        self.console = Console()
 
     def log(self, message, category="INFO"):
         timestamp = datetime.now().strftime("[%H:%M:%S]")
         formatted = f"{timestamp} 🔡️  {category.upper():<10} | {message}"
-        print(formatted)
+        self.console.print(formatted)
         self.logs.append(formatted)
 
     def __call__(self, message, category="INFO"):


### PR DESCRIPTION
## Summary
- add a Rich `Console` to the Logger and use it for printing
- forward the same console to the Dashboard's `Live` display

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68403ab63464832ab3d135565c71412d